### PR TITLE
Fixed 40ants-doc asdf system dependency from the 40ants-doc/ignored-words. Because this module should be in the core system.

### DIFF
--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -150,6 +150,8 @@
                               "*DOCUMENT-DOWNCASE-UPPERCASE-CODE*"
                               ;; These objects are not documented yet:
                               "40ANTS-DOC/COMMONDOC/XREF:XREF"))
+  (0.9.1 2022-10-19
+         "* Fixed 40ants-doc asdf system dependency from the 40ants-doc/ignored-words. Because this module should be in the core system.")
   (0.9.0 2022-02-21
          "* Now you can refer internal documentation section of other libraries.
             To do this, put the link to this library documentation to the

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -5,6 +5,7 @@
   (:import-from #:40ants-doc/reference)
   (:import-from #:40ants-doc/locatives/base)
   (:import-from #:40ants-doc/object-package)
+  (:import-from #:40ants-doc/ignored-words)
   (:import-from #:40ants-doc/docstring
                 #:strip-docstring-indentation)
   (:export #:defsection


### PR DESCRIPTION
This pull should solve this problem:

https://github.com/ultralisp/ultralisp/issues/180