### PR TITLE
Fixed issue with unpacking Highlight.js archive when it is having absolute pathnames.

### DIFF
--- a/full/highlight.lisp
+++ b/full/highlight.lisp
@@ -13,7 +13,8 @@
   ;; https://github.com/highlightjs/highlight.js/issues/3835
   ;; (:import-from #:trivial-extract
   ;;               #:extract-zip)
-  )
+  (:import-from #:which))
+
 (in-package #:40ants-doc-full/highlight)
 
 

--- a/full/highlight.lisp
+++ b/full/highlight.lisp
@@ -7,15 +7,13 @@
                 #:write-string-into-file
                 #:write-byte-vector-into-file
                 #:read-file-into-string)
-  (:import-from #:cl-cookie
-                #:cookie-value
-                #:cookie-name
-                #:make-cookie-jar
-                #:cookie-jar-cookies)
   (:import-from #:tmpdir
                 #:with-tmpdir)
-  (:import-from #:trivial-extract
-                #:extract-zip))
+  ;; TODO: Should be returned back after this issue resolve:
+  ;; https://github.com/highlightjs/highlight.js/issues/3835
+  ;; (:import-from #:trivial-extract
+  ;;               #:extract-zip)
+  )
 (in-package #:40ants-doc-full/highlight)
 
 

--- a/full/highlight.lisp
+++ b/full/highlight.lisp
@@ -13,7 +13,8 @@
   ;; https://github.com/highlightjs/highlight.js/issues/3835
   ;; (:import-from #:trivial-extract
   ;;               #:extract-zip)
-  (:import-from #:which))
+  (:import-from #:which)
+  (:import-from #:jonathan))
 
 (in-package #:40ants-doc-full/highlight)
 

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -152,6 +152,10 @@
                               "*DOCUMENT-DOWNCASE-UPPERCASE-CODE*"
                               ;; These objects are not documented yet:
                               "40ANTS-DOC/COMMONDOC/XREF:XREF"))
+  (0.15.1 2023-08-05
+          "* Fixed issue with unpacking Highlight.js archive when it is having absolute pathnames.
+
+             Also, a new download API is used now.")
   (0.15.0 2023-07-22
           "* Autodoc was fixed to not show packages without external symbols.
            * Also, now autodoc sorts packages alphabetically.")


### PR DESCRIPTION
Closes https://github.com/40ants/doc/issues/34