### PR TITLE
Fixed URLs in the search index file when CLEAN-URLS argument is given.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,18 +18,6 @@
       "strategy": {
         "fail-fast": false,
         "matrix": {
-          "quicklisp": [
-            "quicklisp",
-            "ultralisp"
-          ],
-          "lisp": [
-            "sbcl-bin",
-            "abcl-bin",
-            "clasp",
-            "lispworks",
-            "mkcl",
-            "ecl"
-          ],
           "exclude": [
             {
               "quicklisp": "quicklisp",
@@ -51,6 +39,18 @@
               "quicklisp": "quicklisp",
               "lisp": "ecl"
             }
+          ],
+          "quicklisp": [
+            "quicklisp",
+            "ultralisp"
+          ],
+          "lisp": [
+            "sbcl-bin",
+            "abcl-bin",
+            "clasp",
+            "lispworks",
+            "mkcl",
+            "ecl"
           ]
         }
       },
@@ -67,7 +67,7 @@
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v3",
           "with": {
             "asdf-system": "40ants-doc-full"
           }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v3",
           "with": {
             "asdf-system": "40ants-doc-full"
           }

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -23,7 +23,7 @@
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v3",
           "with": {
             "asdf-system": "40ants-doc"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+{
+  "name": "RELEASE",
+  "on": {
+    "push": {
+      "branches": [
+        "master"
+      ]
+    }
+  },
+  "jobs": {
+    "autotag": {
+      "permissions": {
+        "contents": "write"
+      },
+      "runs-on": "ubuntu-latest",
+      "env": {
+        "OS": "ubuntu-latest"
+      },
+      "steps": [
+        {
+          "name": "Checkout Code",
+          "uses": "actions/checkout@v3"
+        },
+        {
+          "name": "Create release tag",
+          "uses": "butlerlogic/action-autotag@8bc1ad456dcdee34e8c6ffbce991cc31793578c2",
+          "with": {
+            "root": "ChangeLog.md",
+            "regex_pattern": "^## (?<version>\\d+\\.\\d+\\.\\d+.*?)( |\\n).*$",
+            "tag_prefix": "v"
+          },
+          "env": {
+            "GITHUB_TOKEN": "${{ secrets.GITHUB_TOKEN }}"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/full/builder.lisp
+++ b/full/builder.lisp
@@ -324,7 +324,7 @@
         (40ants-doc-full/builder/vars::*base-dir* base-dir)
         (40ants-doc-full/builder/vars::*base-url* base-url)
         (40ants-doc-full/builder/printer::*full-package-names* full-package-names))
-    
+
     (handler-bind ((warning (lambda (c)
                               (declare (ignore c))
                               (incf num-warnings))))
@@ -391,8 +391,8 @@
                                                                :highlight-theme highlight-theme)
 
                     (let* ((page (40ants-doc-full/commondoc/page:make-page nil "search/index"
-                                                                      :title "Search Page"
-                                                                      :format :html))
+                                                                           :title "Search Page"
+                                                                           :format :html))
                            (filename (make-full-filename page)))
                       (ensure-directories-exist filename)
                       (uiop:with-output-file (common-html.emitter::*output-stream*

--- a/full/search.lisp
+++ b/full/search.lisp
@@ -3,9 +3,11 @@
   (:import-from #:40ants-doc-full/commondoc/mapper
                 #:map-nodes)
   (:import-from #:40ants-doc-full/commondoc/section)
-  (:import-from #:40ants-doc-full/commondoc/page)
+  (:import-from #:40ants-doc-full/commondoc/page
+                #:full-filename)
   (:import-from #:40ants-doc-full/page)
-  (:import-from #:40ants-doc-full/utils)
+  (:import-from #:40ants-doc-full/utils
+                #:make-clean-uri)
   (:import-from #:40ants-doc/locatives)
   (:import-from #:common-html)
   (:import-from #:stem)
@@ -24,7 +26,9 @@
                 #:locative-type)
   (:import-from #:common-doc)
   (:import-from #:common-doc.ops
-                #:collect-all-text))
+                #:collect-all-text)
+  (:import-from #:40ants-doc-full/rewrite
+                #:*clean-urls*))
 (in-package #:40ants-doc-full/search)
 
 
@@ -149,9 +153,12 @@
                       (push (40ants-doc-full/utils:make-relative-path (40ants-doc-full/page:base-filename page)
                                                                       (40ants-doc-full/page:base-filename node))
                             docnames)
-                      (push (40ants-doc-full/commondoc/page:full-filename node
-                                                                          :from page)
-                            filenames))))
+                      (let ((path (full-filename node
+                                                 :from page)))
+                        (push (if *clean-urls*
+                                  (make-clean-uri path)
+                                  path)
+                              filenames)))))
                  node)
                (go-up (node)
                  (typecase node

--- a/full/themes/default.lisp
+++ b/full/themes/default.lisp
@@ -10,6 +10,8 @@
                 #:make-relative-path)
   (:import-from #:40ants-doc-full/rewrite)
   (:import-from #:40ants-doc-full/commondoc/changelog)
+  (:import-from #:alexandria
+                #:read-file-into-string)
   (:export #:default-theme))
 (in-package #:40ants-doc-full/themes/default)
 
@@ -282,7 +284,7 @@
         :margin-bottom 1em)))
 
      (.rss-icon
-      :background ,(alexandria:read-file-into-string
+      :background ,(read-file-into-string
                     (asdf:system-relative-pathname :40ants-doc
                                                    "static/rss-icon.base64"))
       :width 1em

--- a/full/utils.lisp
+++ b/full/utils.lisp
@@ -3,7 +3,9 @@
   (:import-from #:40ants-doc-full/builder/vars)
   (:import-from #:alexandria)
   (:import-from #:cl-ppcre)
-  (:import-from #:str)
+  (:import-from #:str
+                #:ensure-suffix
+                #:replace-all)
   (:import-from #:40ants-doc/docstring
                 #:whitespacep
                 #:blankp)
@@ -689,6 +691,13 @@
                         do (write-string "../" s))
                   (push to-part rest-to-parts)
                   (format s "~{~A~^/~}" rest-to-parts)))))))
+
+
+(defun make-clean-uri (path)
+  (ensure-suffix "/"
+                 (replace-all "/index.html"
+                              "/"
+                              path)))
 
 
 (defgeneric maybe-downcase (obj)

--- a/qlfile.lock
+++ b/qlfile.lock
@@ -1,8 +1,8 @@
 ("quicklisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://beta.quicklisp.org/dist/quicklisp.txt" :%version :latest)
-  :version "2023-02-15"))
+  :version "2023-10-21"))
 ("ultralisp" .
  (:class qlot/source/dist:source-dist
   :initargs (:distribution "http://dist.ultralisp.org" :%version :latest)
-  :version "20230417162000"))
+  :version "20240124120001"))

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -150,8 +150,11 @@
                               "*DOCUMENT-MARK-UP-SIGNATURES*"
                               "*DOCUMENT-NORMALIZE-PACKAGES*"
                               "*DOCUMENT-DOWNCASE-UPPERCASE-CODE*"
+                              "CLEAN-URLS"
                               ;; These objects are not documented yet:
                               "40ANTS-DOC/COMMONDOC/XREF:XREF"))
+  (0.15.3 2024-01-24
+          "* Fixed URLs in the search index file when CLEAN-URLS argument is given. This should prevent redirection to index.html file from search page - now index.html will be stripped from the path.")
   (0.15.2 2023-11-28
           "* Fixed stack exhausting when trying to collect dependencies for some ASDF systems.")
   (0.15.1 2023-08-05

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -4,7 +4,9 @@
                 #:defworkflow)
   (:import-from #:40ants-ci/jobs/linter)
   (:import-from #:40ants-ci/jobs/run-tests)
-  (:import-from #:40ants-ci/jobs/docs))
+  (:import-from #:40ants-ci/jobs/docs)
+  (:import-from #:40ants-ci/jobs/autotag
+                #:autotag))
 (in-package #:40ants-doc/ci)
 
 
@@ -24,6 +26,11 @@
         ;; This fails to install under the Roswell on Ubuntu
         ;; "npt"
         "ecl") )
+
+
+(defworkflow release
+  :on-push-to "master"
+  :jobs ((autotag)))
 
 
 (defworkflow linter


### PR DESCRIPTION
This should prevent redirection to index.html file from search page - now index.html will be stripped from the path.