### PR TITLE
Another fix to URLs on the search page.

### DIFF
--- a/full/commondoc/page.lisp
+++ b/full/commondoc/page.lisp
@@ -40,7 +40,8 @@
                 #:page-base-url
                 #:base-filename
                 #:page-format)
-  (:import-from #:40ants-doc-full/rewrite)
+  (:import-from #:40ants-doc-full/rewrite
+                #:*clean-urls*)
   (:import-from #:40ants-doc/locatives/base
                 #:locative-equal)
   (:import-from #:40ants-doc-full/dislocated-symbols
@@ -135,7 +136,10 @@
 
 (defun emit-search-page (page)
   "Emit an piece of documentation."
-  (let* ((uri (make-page-uri page)))
+  (let* ((uri (make-page-uri page))
+         (doc-builder (if *clean-urls*
+                          "dirhtml"
+                          "html")))
     (with-page-template (uri
                          (page-title page)
                          :toc (make-page-toc page))
@@ -143,20 +147,21 @@
         ;; This should go before doctools
         ;; URL_ROOT: document.getElementById('documentation_options').getAttribute('data-url_root'),
         (:script :type "text/javascript"
-                 (:raw "
+                 (:raw (format nil "
 var DOCUMENTATION_OPTIONS = {
     URL_ROOT: '',
     VERSION: '5.0.0+',
     LANGUAGE: 'en',
     COLLAPSE_INDEX: false,
-    BUILDER: 'html',
+    BUILDER: '~A',
     FILE_SUFFIX: '.html',
     LINK_SUFFIX: '.html',
     HAS_SOURCE: true,
     SOURCELINK_SUFFIX: '.txt',
     NAVIGATION_WITH_KEYS: false
 };
-"))
+"
+                               doc-builder)))
         (:script :src (make-relative-path uri "underscore.js"))
         (:script :src (make-relative-path uri "doctools.js"))
         (:script :src (make-relative-path uri "language_data.js"))

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -153,6 +153,8 @@
                               "CLEAN-URLS"
                               ;; These objects are not documented yet:
                               "40ANTS-DOC/COMMONDOC/XREF:XREF"))
+  (0.15.4 2024-01-26
+          "* Another fix to URLs on the search page. Now if CLEAN-URLS argument is true, search page will link to the pages ended with a backslash. Otherwise, it will link to the html pages.")
   (0.15.3 2024-01-24
           "* Fixed URLs in the search index file when CLEAN-URLS argument is given. This should prevent redirection to index.html file from search page - now index.html will be stripped from the path.")
   (0.15.2 2023-11-28


### PR DESCRIPTION
Now if CLEAN-URLS argument is true, search page will link to the pages ended with a backslash. Otherwise, it will link to the html pages.