### PR TITLE
Autodoc macro now accepts IGNORE-SYMBOL-P argument and by default ign…

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,11 +198,19 @@ choose which.
 
 <a id="x-28FOO-RANDOM-3AFOO-RANDOM-STATE-20CLASS-29"></a>
 
+<<<<<<< Updated upstream
 ## [class](0d91) `foo-random:foo-random-state` ()
 
 <a id="x-28FOO-RANDOM-3ASTATE-20-2840ANTS-DOC-2FLOCATIVES-3AREADER-20FOO-RANDOM-3AFOO-RANDOM-STATE-29-29"></a>
 
 ## [reader](d52a) `foo-random:state` (foo-random-state) ()
+=======
+## [class](22c8) `foo-random:foo-random-state` ()
+
+<a id="x-28FOO-RANDOM-3ASTATE-20-2840ANTS-DOC-2FLOCATIVES-3AREADER-20FOO-RANDOM-3AFOO-RANDOM-STATE-29-29"></a>
+
+## [reader](c525) `foo-random:state` (foo-random-state) ()
+>>>>>>> Stashed changes
 
 Returns random foo's state.
 
@@ -210,24 +218,40 @@ Hey we can also print states!
 
 <a id="x-28PRINT-OBJECT-20-28METHOD-20NIL-20-28FOO-RANDOM-3AFOO-RANDOM-STATE-20T-29-29-29"></a>
 
+<<<<<<< Updated upstream
 ## [method](501f) `common-lisp:print-object` (object foo-random-state) stream
 
 <a id="x-28FOO-RANDOM-3A-2AFOO-STATE-2A-20-28VARIABLE-29-29"></a>
 
 ## [variable](ab78) `foo-random:*foo-state*` #<foo-random-state >
+=======
+## [method](37d4) `common-lisp:print-object` (object foo-random-state) stream
+
+<a id="x-28FOO-RANDOM-3A-2AFOO-STATE-2A-20-28VARIABLE-29-29"></a>
+
+## [variable](deae) `foo-random:*foo-state*` #<foo-random-state >
+>>>>>>> Stashed changes
 
 Much like `*RANDOM-STATE*` but uses the `FOO` algorithm.
 
 <a id="x-28FOO-RANDOM-3AGAUSSIAN-RANDOM-20FUNCTION-29"></a>
 
+<<<<<<< Updated upstream
 ## [function](1bb1) `foo-random:gaussian-random` stddev &key (random-state \*foo-state\*)
+=======
+## [function](d75d) `foo-random:gaussian-random` stddev &key (random-state \*foo-state\*)
+>>>>>>> Stashed changes
 
 Return not a random number from a zero mean normal distribution with
 `STDDEV`.
 
 <a id="x-28FOO-RANDOM-3AUNIFORM-RANDOM-20FUNCTION-29"></a>
 
+<<<<<<< Updated upstream
 ## [function](3d30) `foo-random:uniform-random` limit &key (random-state \*foo-state\*)
+=======
+## [function](4cc7) `foo-random:uniform-random` limit &key (random-state \*foo-state\*)
+>>>>>>> Stashed changes
 
 Return a random number from the between 0 and `LIMIT` (exclusive)
 uniform distribution.
@@ -250,12 +274,21 @@ with `FOO`:
 ```
 
 [2133]: #x-28FOO-RANDOM-3A-2AFOO-STATE-2A-20-28VARIABLE-29-29
+<<<<<<< Updated upstream
 [0d91]: https://github.com/40ants/doc/blob/165e8162ca653039e2eb3de1ffa9f28603690678/full/tutorial.lisp#L35
 [d52a]: https://github.com/40ants/doc/blob/165e8162ca653039e2eb3de1ffa9f28603690678/full/tutorial.lisp#L36
 [501f]: https://github.com/40ants/doc/blob/165e8162ca653039e2eb3de1ffa9f28603690678/full/tutorial.lisp#L39
 [ab78]: https://github.com/40ants/doc/blob/165e8162ca653039e2eb3de1ffa9f28603690678/full/tutorial.lisp#L42
 [3d30]: https://github.com/40ants/doc/blob/165e8162ca653039e2eb3de1ffa9f28603690678/full/tutorial.lisp#L45
 [1bb1]: https://github.com/40ants/doc/blob/165e8162ca653039e2eb3de1ffa9f28603690678/full/tutorial.lisp#L51
+=======
+[22c8]: https://github.com/40ants/doc/blob/d6edb93b94c97783e13efa1e39f3b0d0d76cf747/full/tutorial.lisp#L35
+[c525]: https://github.com/40ants/doc/blob/d6edb93b94c97783e13efa1e39f3b0d0d76cf747/full/tutorial.lisp#L36
+[37d4]: https://github.com/40ants/doc/blob/d6edb93b94c97783e13efa1e39f3b0d0d76cf747/full/tutorial.lisp#L39
+[deae]: https://github.com/40ants/doc/blob/d6edb93b94c97783e13efa1e39f3b0d0d76cf747/full/tutorial.lisp#L42
+[4cc7]: https://github.com/40ants/doc/blob/d6edb93b94c97783e13efa1e39f3b0d0d76cf747/full/tutorial.lisp#L45
+[d75d]: https://github.com/40ants/doc/blob/d6edb93b94c97783e13efa1e39f3b0d0d76cf747/full/tutorial.lisp#L51
+>>>>>>> Stashed changes
 ````
 `MGL-PAX` supported the plain text format which was more readble when viewed
 from a simple text editor, but I've dropped support for plain text in this fork

--- a/full/commondoc/page.lisp
+++ b/full/commondoc/page.lisp
@@ -227,9 +227,9 @@ var DOCUMENTATION_OPTIONS = {
              node)
            (documented-p (symbol)
              (member symbol references-symbols)))
-      
+
       (40ants-doc-full/commondoc/mapper:map-nodes node #'collect-packages)
-     
+      
       ;; This blocks extends PACKAGES list with all other
       ;; package-inferred packages for the system
       (when *warn-on-undocumented-packages* (loop with primary-names = nil
@@ -260,17 +260,16 @@ var DOCUMENTATION_OPTIONS = {
                                          '40ants-doc:section)))
                    (push symbol (gethash package undocumented-symbols))))
             finally (unless (zerop (hash-table-count undocumented-symbols))
-                      (warn 
-                       (with-output-to-string (s)
-                         (format s "These symbols are external, but not documented:")
-                         (loop for package being the hash-key of undocumented-symbols
-                                 using (hash-value symbols)
-                               do (format s "~2&  ~A:"
-                                          (package-name package))
-                                  (loop for symbol in (sort symbols #'string<
-                                                            :key #'symbol-name)
-                                        do (format s "~&  - ~A"
-                                                   symbol)))))))))
+                      (warn "These symbols are external, but not documented:~%~A"
+                            (with-output-to-string (s)
+                              (loop for package being the hash-key of undocumented-symbols
+                                    using (hash-value symbols)
+                                    do (format s "~2&  ~A:"
+                                               (package-name package))
+                                       (loop for symbol in (sort symbols #'string<
+                                                                 :key #'symbol-name)
+                                             do (format s "~&  - ~A"
+                                                        symbol)))))))))
   node)
 
 (defun warn-on-references-to-internals (document)

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -155,6 +155,8 @@
                               "CLEAN-URLS"
                               ;; These objects are not documented yet:
                               "40ANTS-DOC/COMMONDOC/XREF:XREF"))
+  (0.24.0 2025-05-12
+          "* Autodoc macro now accepts IGNORE-SYMBOL-P argument and by default ignores symbols starting with `%` character.")
   (0.23.0 2025-01-06
           "* IGNORE-PACKAGES argument was added to DEFSECTION macro. Packages
              listed in this argument allows to muffle this warning:


### PR DESCRIPTION
…ores symbols starting with `%` character.