### PR TITLE
Fixed a bug when class slot accessor or reader was not filtered using…

### DIFF
--- a/src/autodoc.lisp
+++ b/src/autodoc.lisp
@@ -151,7 +151,9 @@
                         ;; Classes
                         when (and (find-class symbol nil)
                                   should-be-documented)
-                          collect (make-class-entry symbol package-name) into classes
+                          collect (make-class-entry symbol package-name
+                                                    :ignore-symbol-p ignore-symbol-p)
+                            into classes
 
                         ;; Variables
                         when (and (documentation symbol 'variable)

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -155,6 +155,8 @@
                               "CLEAN-URLS"
                               ;; These objects are not documented yet:
                               "40ANTS-DOC/COMMONDOC/XREF:XREF"))
+  (0.24.1 2025-05-26
+          "* Fixed a bug when class slot accessor or reader was not filtered using a custom function passed as IGNORE-SYMBOL-P argument.")
   (0.24.0 2025-05-12
           "* Autodoc macro now accepts IGNORE-SYMBOL-P argument and by default ignores symbols starting with `%` character.")
   (0.23.0 2025-01-06


### PR DESCRIPTION
… a custom function passed as IGNORE-SYMBOL-P argument.